### PR TITLE
Use regular expression to break apart SRL relation

### DIFF
--- a/core/src/main/scala/edu/knowitall/tool/srl/Frame.scala
+++ b/core/src/main/scala/edu/knowitall/tool/srl/Frame.scala
@@ -30,9 +30,10 @@ case class Relation(node: DependencyNode, name: String, sense: String) {
   def serialize = name + "_" + node.index + "." + sense
 }
 object Relation {
+  val relationRegex = "(.*)\\.(.*)".r
   def fromString(node: DependencyNode, string: String) = {
-    val (name, sense) = string.split("\\.") match {
-      case Array(name, sense) => (name, sense)
+    val (name, sense) = string match {
+      case relationRegex(name, sense) => (name, sense)
       case _ => throw new MatchError("Could not create relation with node " + node + " from string: " + string)
     }
     Relation(node, name, sense)


### PR DESCRIPTION
Fixes https://github.com/knowitall/srlie/issues/3.

Split would fail because sometimes the SRL relation string would contain a period, causing the string to be split into three parts instead of only two.
