### PR TITLE
Replace restricted characters in relation verb.

### DIFF
--- a/core/src/main/scala/edu/knowitall/tool/srl/Frame.scala
+++ b/core/src/main/scala/edu/knowitall/tool/srl/Frame.scala
@@ -36,7 +36,13 @@ object Relation {
       case relationRegex(name, sense) => (name, sense)
       case _ => throw new MatchError("Could not create relation with node " + node + " from string: " + string)
     }
-    Relation(node, name, sense)
+
+    // replace restricted characters
+    def cleanName = name
+      .replaceAll("\\[", "(")
+      .replaceAll("\\]", ")")
+      .replaceAll(":", "-")
+    Relation(node, cleanName, sense)
   }
 
   def deserialize(dgraph: DependencyGraph)(pickled: String) = {


### PR DESCRIPTION
This is a hack to prevent exceptions when the relation
verb contains a restricted character.  It would be better
to escape the characters, but that would be considerably
more work and there is almost never a ':', '[', or ']'
in the relation of a semantic frame.
