### PR TITLE
Skip over control characters when computing offsets.

### DIFF
--- a/core/src/main/scala/edu/knowitall/tool/tokenize/Tokenizer.scala
+++ b/core/src/main/scala/edu/knowitall/tool/tokenize/Tokenizer.scala
@@ -22,7 +22,7 @@ object Tokenizer {
     var tokens: Seq[Token] = Seq.empty
 
     // remove leading spaces
-    val (spaces, rest) = sent.span(_.isWhitespace)
+    val (spaces, rest) = sent.span(c => c.isWhitespace || c.isControl)
     offset += spaces.size
     sent = rest
 
@@ -31,7 +31,7 @@ object Tokenizer {
       assume(sent startsWith string, "Wrong sentence prefix: '" + string + "' of " + "'" + sentence + "'")
 
       sent = sent.drop(string.length)
-      val skip = sent.takeWhile(_.isWhitespace).length
+      val skip = sent.takeWhile(c => c.isWhitespace || c.isControl).length
       sent = sent.drop(skip)
 
       offset += string.length + skip

--- a/tokenize/clear/src/test/scala/edu/knowitall/tool/tokenize/ClearTokenizerTest.scala
+++ b/tokenize/clear/src/test/scala/edu/knowitall/tool/tokenize/ClearTokenizerTest.scala
@@ -15,5 +15,10 @@ object ClearTokenizerTest extends Specification {
     val tokenizer = new ClearTokenizer()
     tokenizer(text).mkString(" ") must_== "This@0 is@5 a@8 test@10 of@15 Clear@18 's@23 tokenizer@26 .@35"
   }
-}
 
+  "tokenize pathological sentence" in {
+    val text = "rough straight and"
+    val tokenizer = new ClearTokenizer()
+    tokenizer(text).mkString(" ") must_== "rough@0 straight@7 and@16"
+  }
+}


### PR DESCRIPTION
Otherwise an exception was thrown because OpenNlp and Clear treat control characters as whitespace.
